### PR TITLE
feat: implement device-auth for android (and hopefully other platforms)

### DIFF
--- a/android/app/src/main/kotlin/com/example/cards/MainActivity.java
+++ b/android/app/src/main/kotlin/com/example/cards/MainActivity.java
@@ -3,10 +3,10 @@ package com.toxdes.cards;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
-import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.android.FlutterFragmentActivity;
 import io.flutter.plugin.common.MethodChannel;
 
-public class MainActivity extends FlutterActivity {
+public class MainActivity extends FlutterFragmentActivity{
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -16,25 +16,25 @@ public class MainActivity extends FlutterActivity {
   @Override
   public void configureFlutterEngine(io.flutter.embedding.engine.FlutterEngine flutterEngine) {
     super.configureFlutterEngine(flutterEngine);
-    
+
     String packageName = getApplicationContext().getPackageName();
-    
+
     new MethodChannel(flutterEngine.getDartExecutor().getBinaryMessenger(), packageName)
         .setMethodCallHandler((call, result) -> {
           if (call.method.equals("showNotificationWithAction")) {
             String title = call.argument("title");
             String body = call.argument("body");
-            
+
             Intent serviceIntent = new Intent(getApplicationContext(), CardsForegroundService.class);
             serviceIntent.putExtra(CardsForegroundService.EXTRA_TITLE, title);
             serviceIntent.putExtra(CardsForegroundService.EXTRA_BODY, body);
-            
+
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
               getApplicationContext().startForegroundService(serviceIntent);
             } else {
               getApplicationContext().startService(serviceIntent);
             }
-            
+
             result.success(null);
           } else {
             result.notImplemented();

--- a/android/app/src/main/kotlin/com/example/cards/MainActivity.java
+++ b/android/app/src/main/kotlin/com/example/cards/MainActivity.java
@@ -6,6 +6,8 @@ import android.os.Bundle;
 import io.flutter.embedding.android.FlutterFragmentActivity;
 import io.flutter.plugin.common.MethodChannel;
 
+// We use FlutterFragmentActivity here because local_auth needs a FragmentActivity
+// to be able to show system level device-auth popup
 public class MainActivity extends FlutterFragmentActivity{
 
   @Override

--- a/lib/components/home/filter_controls.dart
+++ b/lib/components/home/filter_controls.dart
@@ -14,13 +14,13 @@ class FilterControls extends StatelessWidget {
   Widget build(BuildContext context) {
     return Consumer<CardsNotifier>(builder: (context, cardsNotifier, _) {
       Set<Filter<CardModel>> all = getAllFilters();
-      EdgeInsets chipPadding = EdgeInsets.fromLTRB(12, 4, 12, 4);
+      EdgeInsets chipPadding = const EdgeInsets.fromLTRB(12, 4, 12, 4);
 
       // TODO: currently these are hardcoded, plan is to have user created filter "shortcuts", which will replace these hardcoded ones.
       List<Widget> specialFilterChips = all.map((Filter<CardModel> f) {
         bool isActive = cardsNotifier.isFilterActive(f);
         return Container(
-          margin: EdgeInsets.fromLTRB(0, 0, 8, 0),
+          margin: const EdgeInsets.fromLTRB(0, 0, 8, 0),
           child: Chip(
               checked: isActive,
               label: f.label,
@@ -36,7 +36,7 @@ class FilterControls extends StatelessWidget {
       }).toList();
 
       return Padding(
-          padding: EdgeInsets.fromLTRB(0, 4, 0, 4),
+          padding: const EdgeInsets.fromLTRB(0, 4, 0, 4),
           child: Row(
             mainAxisSize: MainAxisSize.max,
             mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/components/home/header.dart
+++ b/lib/components/home/header.dart
@@ -30,7 +30,7 @@ class Header extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       // color: ThemeColors.red,
-      padding: EdgeInsets.fromLTRB(0, 12, 0, 0),
+      padding: const EdgeInsets.fromLTRB(0, 12, 0, 0),
       child: Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
         Container(
           alignment: Alignment.centerLeft,

--- a/lib/components/home/sort_and_filter_form.dart
+++ b/lib/components/home/sort_and_filter_form.dart
@@ -242,7 +242,7 @@ class _SortAndFilterFormState extends State<SortAndFilterForm> {
                 labelColor: ThemeColors.red,
                 buttonType: ButtonType.ghost,
                 onTap: _resetForm,
-                padding: EdgeInsets.fromLTRB(0, 0, 0, 0),
+                padding: const EdgeInsets.fromLTRB(0, 0, 0, 0),
                 alignment: Alignment.center,
                 height: 42,
                 label: "Reset filters",

--- a/lib/components/preferences/menu_item.dart
+++ b/lib/components/preferences/menu_item.dart
@@ -174,13 +174,13 @@ class MenuItem extends StatelessWidget {
                         )
                       : SizedBox.shrink()
                 ]),
-            Icon(
-              Icons.chevron_right_outlined,
-              color: ThemeColors.white2,
-              size: 18,
-            ),
           ],
-        )
+        ),
+        Icon(
+          Icons.chevron_right_outlined,
+          color: ThemeColors.white2,
+          size: 18,
+        ),
       ]),
     );
   }
@@ -206,7 +206,7 @@ class MenuItemBase extends StatelessWidget {
         child: Opacity(
           opacity: disabled ? disabledOpacity : 1,
           child: Container(
-            padding: EdgeInsets.symmetric(horizontal: 24),
+            padding: const EdgeInsets.symmetric(horizontal: 24),
             height: 64,
             decoration: BoxDecoration(
                 color: bgColor,

--- a/lib/components/preferences/menu_item.dart
+++ b/lib/components/preferences/menu_item.dart
@@ -15,6 +15,7 @@ class MenuItemWithSwitch extends StatelessWidget {
       this.fgColor = ThemeColors.white2,
       this.bgColor = ThemeColors.gray1,
       this.borderColor = ThemeColors.gray3,
+      this.descColor = ThemeColors.white3,
       this.disabled = false});
 
   final ValueSetter<bool> onChange;
@@ -23,7 +24,12 @@ class MenuItemWithSwitch extends StatelessWidget {
   final String? desc;
   final IconData? icon;
   final bool disabled;
-  final Color fgColor, bgColor, borderColor, iconColor;
+  final Color fgColor, bgColor, borderColor, iconColor, descColor;
+
+  void onTap() {
+    if (disabled) return;
+    onChange(!checked);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -31,39 +37,69 @@ class MenuItemWithSwitch extends StatelessWidget {
       bgColor: bgColor,
       borderColor: borderColor,
       disabled: disabled,
-      onTap: () {
-        onChange(!checked);
-      },
+      onTap: onTap,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Row(
-            children: [
-              icon != null
-                  ? Icon(
-                      icon,
-                      color: iconColor,
-                    )
-                  : SizedBox.shrink(),
-              SizedBox(width: 8),
-              Text(
-                title,
-                style: TextStyle(
-                  fontFamily: Fonts.rubik,
-                  fontSize: 16,
-                  fontWeight: FontWeight.w400,
-                  color: fgColor,
-                  decoration: TextDecoration.none,
+          Expanded(
+            child: Row(
+              children: [
+                icon != null
+                    ? Icon(
+                        icon,
+                        color: iconColor,
+                      )
+                    : SizedBox.shrink(),
+                SizedBox(width: 12),
+                Flexible(
+                  fit: FlexFit.tight,
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        style: TextStyle(
+                          fontFamily: Fonts.rubik,
+                          fontSize: 16,
+                          fontWeight: FontWeight.w400,
+                          color: fgColor,
+                          decoration: TextDecoration.none,
+                        ),
+                        textAlign: TextAlign.left,
+                      ),
+                      desc != null
+                          ? const SizedBox(height: 4)
+                          : SizedBox.shrink(),
+                      desc != null
+                          ? Text(
+                              desc!,
+                              maxLines: 3,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(
+                                fontFamily: Fonts.rubik,
+                                fontSize: 12,
+                                fontWeight: FontWeight.w400,
+                                color: descColor,
+                                decoration: TextDecoration.none,
+                              ),
+                              softWrap: true,
+                              textAlign: TextAlign.left,
+                            )
+                          : SizedBox.shrink(),
+                    ],
+                  ),
                 ),
-                textAlign: TextAlign.left,
-              ),
-            ],
+              ],
+            ),
           ),
           CupertinoSwitch(
               value: checked,
               activeTrackColor: ThemeColors.blue,
               inactiveTrackColor: ThemeColors.gray3,
-              onChanged: (_) {}),
+              onChanged: (_) {
+                onTap();
+              }),
         ],
       ),
     );
@@ -81,6 +117,7 @@ class MenuItem extends StatelessWidget {
     this.fgColor = ThemeColors.white2,
     this.bgColor = ThemeColors.gray1,
     this.borderColor = ThemeColors.gray3,
+    this.descColor = ThemeColors.white3,
     this.disabled = false,
   });
   final VoidCallback onTap;
@@ -88,7 +125,7 @@ class MenuItem extends StatelessWidget {
   final String? desc;
   final IconData? icon;
   final bool disabled;
-  final Color fgColor, bgColor, iconColor, borderColor;
+  final Color fgColor, bgColor, iconColor, borderColor, descColor;
   @override
   Widget build(BuildContext context) {
     return MenuItemBase(
@@ -96,35 +133,55 @@ class MenuItem extends StatelessWidget {
       borderColor: borderColor,
       disabled: disabled,
       bgColor: bgColor,
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Row(
-            children: [
-              icon != null
-                  ? Icon(icon, color: ThemeColors.white2)
-                  : SizedBox.shrink(),
-              SizedBox(width: 8),
-              Text(
-                title,
-                style: TextStyle(
-                  fontFamily: Fonts.rubik,
-                  fontSize: 16,
-                  fontWeight: FontWeight.w400,
-                  color: ThemeColors.white2,
-                  decoration: TextDecoration.none,
-                ),
-                textAlign: TextAlign.left,
-              ),
-            ],
-          ),
-          Icon(
-            Icons.chevron_right_outlined,
-            color: ThemeColors.white2,
-            size: 18,
-          )
-        ],
-      ),
+      child: Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
+        Row(
+          children: [
+            icon != null
+                ? Icon(icon, color: ThemeColors.white2)
+                : SizedBox.shrink(),
+            SizedBox(width: 12),
+            Column(
+                mainAxisSize: MainAxisSize.max,
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    maxLines: 3,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontFamily: Fonts.rubik,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w400,
+                      color: fgColor,
+                      decoration: TextDecoration.none,
+                    ),
+                    textAlign: TextAlign.left,
+                  ),
+                  desc != null ? const SizedBox(height: 4) : SizedBox.shrink(),
+                  desc != null
+                      ? Text(
+                          desc!,
+                          style: TextStyle(
+                            fontFamily: Fonts.rubik,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w400,
+                            color: descColor,
+                            decoration: TextDecoration.none,
+                          ),
+                          softWrap: true,
+                          textAlign: TextAlign.left,
+                        )
+                      : SizedBox.shrink()
+                ]),
+            Icon(
+              Icons.chevron_right_outlined,
+              color: ThemeColors.white2,
+              size: 18,
+            ),
+          ],
+        )
+      ]),
     );
   }
 }

--- a/lib/components/preferences/menu_item.dart
+++ b/lib/components/preferences/menu_item.dart
@@ -26,9 +26,9 @@ class MenuItemWithSwitch extends StatelessWidget {
   final bool disabled;
   final Color fgColor, bgColor, borderColor, iconColor, descColor;
 
-  void onTap() {
+  void onTap(bool newValue) {
     if (disabled) return;
-    onChange(!checked);
+    onChange(newValue);
   }
 
   @override
@@ -37,7 +37,9 @@ class MenuItemWithSwitch extends StatelessWidget {
       bgColor: bgColor,
       borderColor: borderColor,
       disabled: disabled,
-      onTap: onTap,
+      onTap: () {
+        onTap(!checked);
+      },
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
@@ -49,7 +51,7 @@ class MenuItemWithSwitch extends StatelessWidget {
                         icon,
                         color: iconColor,
                       )
-                    : SizedBox.shrink(),
+                    : const SizedBox.shrink(),
                 SizedBox(width: 12),
                 Flexible(
                   fit: FlexFit.tight,
@@ -70,7 +72,7 @@ class MenuItemWithSwitch extends StatelessWidget {
                       ),
                       desc != null
                           ? const SizedBox(height: 4)
-                          : SizedBox.shrink(),
+                          : const SizedBox.shrink(),
                       desc != null
                           ? Text(
                               desc!,
@@ -86,7 +88,7 @@ class MenuItemWithSwitch extends StatelessWidget {
                               softWrap: true,
                               textAlign: TextAlign.left,
                             )
-                          : SizedBox.shrink(),
+                          : const SizedBox.shrink(),
                     ],
                   ),
                 ),
@@ -97,9 +99,11 @@ class MenuItemWithSwitch extends StatelessWidget {
               value: checked,
               activeTrackColor: ThemeColors.blue,
               inactiveTrackColor: ThemeColors.gray3,
-              onChanged: (_) {
-                onTap();
-              }),
+              onChanged: disabled
+                  ? null
+                  : (bool newValue) {
+                      onTap(newValue);
+                    }),
         ],
       ),
     );
@@ -172,7 +176,7 @@ class MenuItem extends StatelessWidget {
                           softWrap: true,
                           textAlign: TextAlign.left,
                         )
-                      : SizedBox.shrink()
+                      : const SizedBox.shrink()
                 ]),
           ],
         ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,12 @@
+import 'package:cards/components/shared/spinner.dart';
 import 'package:cards/components/shared/toast.dart';
 import 'package:cards/config/colors.dart';
+import 'package:cards/providers/auth_notifier.dart';
 import 'package:cards/providers/cards_notifier.dart';
 import 'package:cards/providers/preferences_notifier.dart';
 import 'package:cards/screens/home.dart';
+import 'package:cards/screens/locked_screen.dart';
+import 'package:cards/services/auth_service.dart';
 import 'package:cards/services/backup_service.dart';
 import 'package:cards/services/migrations_service.dart';
 import 'package:cards/services/notification_service.dart';
@@ -16,17 +20,33 @@ import 'package:window_manager/window_manager.dart';
 Widget app = MultiProvider(
   providers: [
     ChangeNotifierProvider(create: (_) => CardsNotifier()),
-    ChangeNotifierProvider(create: (_) => PreferencesNotifier())
+    ChangeNotifierProvider(create: (_) => PreferencesNotifier()),
+    ChangeNotifierProvider(create: (_) => AuthNotifier()),
   ],
   child: MaterialApp(
     navigatorKey: ToastManager().navigatorKey,
-    home: const Scaffold(body: Home(), backgroundColor: ThemeColors.gray1),
+    home: Scaffold(
+        body: Consumer2<AuthNotifier, PreferencesNotifier>(
+          builder: (context, authNotifier, prefsNotifier, _) {
+            if (!prefsNotifier.isLoaded) {
+              return Center(
+                  child: Spinner(color: ThemeColors.white2, size: 14));
+            }
+            if (authNotifier.needsAuth(prefsNotifier.prefs.useDeviceAuth)) {
+              return const LockedScreen();
+            }
+            return const Home();
+          },
+        ),
+        backgroundColor: ThemeColors.gray1),
     navigatorObservers: [SentryService.getNavigatorObserver()],
   ),
 );
+
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-
+  // TODO: refactor this so there is no "implicit" order betweeen services, if possible
+  await AuthService.init();
   await NotificationService.init();
   await CryptoUtils.init();
   await MigrationsService.runMigrations();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,7 +45,7 @@ Widget app = MultiProvider(
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  // TODO: refactor this so there is no "implicit" order betweeen services, if possible
+  // TODO: refactor this so there is no "implicit" order between services, if possible
   await AuthService.init();
   await NotificationService.init();
   await CryptoUtils.init();

--- a/lib/providers/auth_notifier.dart
+++ b/lib/providers/auth_notifier.dart
@@ -1,0 +1,30 @@
+import 'package:cards/services/auth_service.dart';
+import 'package:flutter/material.dart';
+
+class AuthNotifier extends ChangeNotifier {
+  bool _authenticated = false;
+  bool _isAuthInProgress = false;
+
+  bool needsAuth(bool deviceAuthEnabled) {
+    return deviceAuthEnabled &&
+        AuthService.isAuthSupported() &&
+        !_authenticated;
+  }
+
+  bool isAuthInProgress() {
+    return _isAuthInProgress;
+  }
+
+  Future<bool> authenticate() async {
+    if (!AuthService.isAuthSupported()) return false;
+    if (_isAuthInProgress) return false;
+    if (_authenticated) return _authenticated;
+
+    _isAuthInProgress = true;
+    notifyListeners();
+    _authenticated = await AuthService.authenticate();
+    _isAuthInProgress = false;
+    notifyListeners();
+    return _authenticated;
+  }
+}

--- a/lib/providers/card_filters.dart
+++ b/lib/providers/card_filters.dart
@@ -4,8 +4,8 @@ import 'package:cards/models/card/card.dart';
 class DebitCardFilter extends Filter<CardModel> {
   @override
   bool ok(CardModel t) {
-    return t.getCardType() == CardType.debit ||
-        t.getTitle().toLowerCase().contains("debit");
+    // TODO: get rid of name based filters once edit-card functionality is added
+    return t.getTitle().toLowerCase().contains("debit");
   }
 
   @override
@@ -15,7 +15,8 @@ class DebitCardFilter extends Filter<CardModel> {
 class CreditCardFilter extends Filter<CardModel> {
   @override
   bool ok(CardModel t) {
-    return t.type == CardType.credit;
+    // TODO: get rid of name based filters once edit-card functionality is added
+    return !t.getTitle().toLowerCase().contains("debit");
   }
 
   @override

--- a/lib/screens/backup_restore/backup_main.dart
+++ b/lib/screens/backup_restore/backup_main.dart
@@ -45,7 +45,7 @@ class _BackupScreenState extends State<BackupMainScreen> {
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           Container(
-            padding: EdgeInsets.fromLTRB(24, 12, 24, 12),
+            padding: const EdgeInsets.fromLTRB(24, 12, 24, 12),
             child: Stack(
               children: [
                 Container(

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -131,7 +131,6 @@ class _HomeState extends State<Home> with TrayListener, WindowListener {
   @override
   Widget build(BuildContext context) {
     return Consumer<PreferencesNotifier>(builder: (context, prefsNotifier, _) {
-      if (prefsNotifier.prefs.useDeviceAuth && AuthService.isAuthSupported()) {}
       return Consumer<CardsNotifier>(
         builder: (context, cardsNotifier, _) {
           List<Widget> cards =

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -12,6 +12,8 @@ import 'package:cards/core/db/sort.dart';
 import 'package:cards/models/card/card.dart';
 import 'package:cards/providers/card_filters.dart';
 import 'package:cards/providers/cards_notifier.dart';
+import 'package:cards/providers/preferences_notifier.dart';
+import 'package:cards/services/auth_service.dart';
 import 'package:cards/services/flavor_service.dart';
 import 'package:cards/services/platform_service.dart';
 import 'package:flutter/cupertino.dart';
@@ -128,116 +130,119 @@ class _HomeState extends State<Home> with TrayListener, WindowListener {
 
   @override
   Widget build(BuildContext context) {
-    return Consumer<CardsNotifier>(
-      builder: (context, cardsNotifier, _) {
-        List<Widget> cards =
-            cardsNotifier.getFilteredCards().map((CardModel c) {
-          return CardView(
-              card: c,
-              onLongPress: (CardModel sc) async {
-                cardsNotifier.removeCard(sc);
-              });
-        }).toList();
-        return SafeArea(
-          child: Center(
-            child: Container(
-                decoration: const BoxDecoration(color: ThemeColors.gray1),
-                constraints: const BoxConstraints(maxWidth: 600),
-                child: Stack(textDirection: TextDirection.ltr, children: [
-                  Container(
-                      padding: const EdgeInsets.fromLTRB(24, 0, 24, 0),
-                      child: Directionality(
-                          textDirection: TextDirection.ltr,
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.end,
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              const Header(),
-                              const SizedBox(height: 6),
-                              cardsNotifier.getCardsCount() > 0
-                                  ? FilterControls(
-                                      onTuneIconTap: () {
-                                        setState(() {
-                                          _sortAndFilterModalVisible = true;
-                                        });
-                                      },
-                                    )
-                                  : const SizedBox.shrink(),
-                              const FilterSummary(),
-                              Expanded(
-                                  child: ListView(
-                                padding:
-                                    const EdgeInsets.symmetric(vertical: 8.0),
-                                scrollDirection: Axis.vertical,
-                                shrinkWrap: true,
-                                children:
-                                    cards.isEmpty ? [CardListEmpty()] : cards,
-                              )),
-                              Button(
-                                label: "Add new card +",
-                                color: ThemeColors.blue,
-                                buttonType: ButtonType.primary,
-                                alignment: Alignment.center,
-                                height: 48,
-                                onTap: () {
-                                  setState(() {
-                                    _addNewCardFormVisible = true;
-                                  });
-                                },
-                              )
-                                  .animate(
-                                      autoPlay: true,
-                                      onComplete: (controller) {
-                                        controller.loop(count: 3);
-                                      })
-                                  .then(delay: 10.seconds)
-                                  .shake(
-                                    duration: 600.ms,
-                                    rotation: 0.02,
-                                  ),
-                              SizedBox(height: 12),
-                            ],
-                          ))),
-                  AddNewCardModal(
-                    isVisible: _addNewCardFormVisible,
-                    onClose: () {
-                      setState(() {
-                        _addNewCardFormVisible = false;
-                      });
-                    },
-                    onAddNewCard: (CardModel card) async {
-                      await cardsNotifier.addCard(card);
-                      if (mounted) {
+    return Consumer<PreferencesNotifier>(builder: (context, prefsNotifier, _) {
+      if (prefsNotifier.prefs.useDeviceAuth && AuthService.isAuthSupported()) {}
+      return Consumer<CardsNotifier>(
+        builder: (context, cardsNotifier, _) {
+          List<Widget> cards =
+              cardsNotifier.getFilteredCards().map((CardModel c) {
+            return CardView(
+                card: c,
+                onLongPress: (CardModel sc) async {
+                  cardsNotifier.removeCard(sc);
+                });
+          }).toList();
+          return SafeArea(
+            child: Center(
+              child: Container(
+                  decoration: const BoxDecoration(color: ThemeColors.gray1),
+                  constraints: const BoxConstraints(maxWidth: 600),
+                  child: Stack(textDirection: TextDirection.ltr, children: [
+                    Container(
+                        padding: const EdgeInsets.fromLTRB(24, 0, 24, 0),
+                        child: Directionality(
+                            textDirection: TextDirection.ltr,
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.end,
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                const Header(),
+                                const SizedBox(height: 6),
+                                cardsNotifier.getCardsCount() > 0
+                                    ? FilterControls(
+                                        onTuneIconTap: () {
+                                          setState(() {
+                                            _sortAndFilterModalVisible = true;
+                                          });
+                                        },
+                                      )
+                                    : const SizedBox.shrink(),
+                                const FilterSummary(),
+                                Expanded(
+                                    child: ListView(
+                                  padding:
+                                      const EdgeInsets.symmetric(vertical: 8.0),
+                                  scrollDirection: Axis.vertical,
+                                  shrinkWrap: true,
+                                  children:
+                                      cards.isEmpty ? [CardListEmpty()] : cards,
+                                )),
+                                Button(
+                                  label: "Add new card +",
+                                  color: ThemeColors.blue,
+                                  buttonType: ButtonType.primary,
+                                  alignment: Alignment.center,
+                                  height: 48,
+                                  onTap: () {
+                                    setState(() {
+                                      _addNewCardFormVisible = true;
+                                    });
+                                  },
+                                )
+                                    .animate(
+                                        autoPlay: true,
+                                        onComplete: (controller) {
+                                          controller.loop(count: 3);
+                                        })
+                                    .then(delay: 10.seconds)
+                                    .shake(
+                                      duration: 600.ms,
+                                      rotation: 0.02,
+                                    ),
+                                SizedBox(height: 12),
+                              ],
+                            ))),
+                    AddNewCardModal(
+                      isVisible: _addNewCardFormVisible,
+                      onClose: () {
                         setState(() {
                           _addNewCardFormVisible = false;
                         });
-                      }
-                    },
-                  ),
-                  SortAndFilterModal(
-                    isVisible: _sortAndFilterModalVisible,
-                    onClose: () {
-                      setState(() {
-                        _sortAndFilterModalVisible = false;
-                      });
-                    },
-                    onApplyFilter: _onApplyFilter,
-                  ),
-                  Positioned(
-                    bottom: 4,
-                    right: 4,
-                    child: Text(FlavorService.getFlavor().getLabel(),
-                        textAlign: TextAlign.left,
-                        style: const TextStyle(
-                            fontFamily: Fonts.rubik,
-                            fontSize: 12,
-                            fontWeight: FontWeight.w600,
-                            color: ThemeColors.yellow)),
-                  ),
-                ])),
-          ),
-        );
-      },
-    );
+                      },
+                      onAddNewCard: (CardModel card) async {
+                        await cardsNotifier.addCard(card);
+                        if (mounted) {
+                          setState(() {
+                            _addNewCardFormVisible = false;
+                          });
+                        }
+                      },
+                    ),
+                    SortAndFilterModal(
+                      isVisible: _sortAndFilterModalVisible,
+                      onClose: () {
+                        setState(() {
+                          _sortAndFilterModalVisible = false;
+                        });
+                      },
+                      onApplyFilter: _onApplyFilter,
+                    ),
+                    Positioned(
+                      bottom: 4,
+                      right: 4,
+                      child: Text(FlavorService.getFlavor().getLabel(),
+                          textAlign: TextAlign.left,
+                          style: const TextStyle(
+                              fontFamily: Fonts.rubik,
+                              fontSize: 12,
+                              fontWeight: FontWeight.w600,
+                              color: ThemeColors.yellow)),
+                    ),
+                  ])),
+            ),
+          );
+        },
+      );
+    });
   }
 }

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -12,8 +12,6 @@ import 'package:cards/core/db/sort.dart';
 import 'package:cards/models/card/card.dart';
 import 'package:cards/providers/card_filters.dart';
 import 'package:cards/providers/cards_notifier.dart';
-import 'package:cards/providers/preferences_notifier.dart';
-import 'package:cards/services/auth_service.dart';
 import 'package:cards/services/flavor_service.dart';
 import 'package:cards/services/platform_service.dart';
 import 'package:flutter/cupertino.dart';
@@ -130,118 +128,116 @@ class _HomeState extends State<Home> with TrayListener, WindowListener {
 
   @override
   Widget build(BuildContext context) {
-    return Consumer<PreferencesNotifier>(builder: (context, prefsNotifier, _) {
-      return Consumer<CardsNotifier>(
-        builder: (context, cardsNotifier, _) {
-          List<Widget> cards =
-              cardsNotifier.getFilteredCards().map((CardModel c) {
-            return CardView(
-                card: c,
-                onLongPress: (CardModel sc) async {
-                  cardsNotifier.removeCard(sc);
-                });
-          }).toList();
-          return SafeArea(
-            child: Center(
-              child: Container(
-                  decoration: const BoxDecoration(color: ThemeColors.gray1),
-                  constraints: const BoxConstraints(maxWidth: 600),
-                  child: Stack(textDirection: TextDirection.ltr, children: [
-                    Container(
-                        padding: const EdgeInsets.fromLTRB(24, 0, 24, 0),
-                        child: Directionality(
-                            textDirection: TextDirection.ltr,
-                            child: Column(
-                              mainAxisAlignment: MainAxisAlignment.end,
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                const Header(),
-                                const SizedBox(height: 6),
-                                cardsNotifier.getCardsCount() > 0
-                                    ? FilterControls(
-                                        onTuneIconTap: () {
-                                          setState(() {
-                                            _sortAndFilterModalVisible = true;
-                                          });
-                                        },
-                                      )
-                                    : const SizedBox.shrink(),
-                                const FilterSummary(),
-                                Expanded(
-                                    child: ListView(
-                                  padding:
-                                      const EdgeInsets.symmetric(vertical: 8.0),
-                                  scrollDirection: Axis.vertical,
-                                  shrinkWrap: true,
-                                  children:
-                                      cards.isEmpty ? [CardListEmpty()] : cards,
-                                )),
-                                Button(
-                                  label: "Add new card +",
-                                  color: ThemeColors.blue,
-                                  buttonType: ButtonType.primary,
-                                  alignment: Alignment.center,
-                                  height: 48,
-                                  onTap: () {
-                                    setState(() {
-                                      _addNewCardFormVisible = true;
-                                    });
-                                  },
-                                )
-                                    .animate(
-                                        autoPlay: true,
-                                        onComplete: (controller) {
-                                          controller.loop(count: 3);
-                                        })
-                                    .then(delay: 10.seconds)
-                                    .shake(
-                                      duration: 600.ms,
-                                      rotation: 0.02,
-                                    ),
-                                SizedBox(height: 12),
-                              ],
-                            ))),
-                    AddNewCardModal(
-                      isVisible: _addNewCardFormVisible,
-                      onClose: () {
+    return Consumer<CardsNotifier>(
+      builder: (context, cardsNotifier, _) {
+        List<Widget> cards =
+            cardsNotifier.getFilteredCards().map((CardModel c) {
+          return CardView(
+              card: c,
+              onLongPress: (CardModel sc) async {
+                cardsNotifier.removeCard(sc);
+              });
+        }).toList();
+        return SafeArea(
+          child: Center(
+            child: Container(
+                decoration: const BoxDecoration(color: ThemeColors.gray1),
+                constraints: const BoxConstraints(maxWidth: 600),
+                child: Stack(textDirection: TextDirection.ltr, children: [
+                  Container(
+                      padding: const EdgeInsets.fromLTRB(24, 0, 24, 0),
+                      child: Directionality(
+                          textDirection: TextDirection.ltr,
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.end,
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              const Header(),
+                              const SizedBox(height: 6),
+                              cardsNotifier.getCardsCount() > 0
+                                  ? FilterControls(
+                                      onTuneIconTap: () {
+                                        setState(() {
+                                          _sortAndFilterModalVisible = true;
+                                        });
+                                      },
+                                    )
+                                  : const SizedBox.shrink(),
+                              const FilterSummary(),
+                              Expanded(
+                                  child: ListView(
+                                padding:
+                                    const EdgeInsets.symmetric(vertical: 8.0),
+                                scrollDirection: Axis.vertical,
+                                shrinkWrap: true,
+                                children:
+                                    cards.isEmpty ? [CardListEmpty()] : cards,
+                              )),
+                              Button(
+                                label: "Add new card +",
+                                color: ThemeColors.blue,
+                                buttonType: ButtonType.primary,
+                                alignment: Alignment.center,
+                                height: 48,
+                                onTap: () {
+                                  setState(() {
+                                    _addNewCardFormVisible = true;
+                                  });
+                                },
+                              )
+                                  .animate(
+                                      autoPlay: true,
+                                      onComplete: (controller) {
+                                        controller.loop(count: 3);
+                                      })
+                                  .then(delay: 10.seconds)
+                                  .shake(
+                                    duration: 600.ms,
+                                    rotation: 0.02,
+                                  ),
+                              SizedBox(height: 12),
+                            ],
+                          ))),
+                  AddNewCardModal(
+                    isVisible: _addNewCardFormVisible,
+                    onClose: () {
+                      setState(() {
+                        _addNewCardFormVisible = false;
+                      });
+                    },
+                    onAddNewCard: (CardModel card) async {
+                      await cardsNotifier.addCard(card);
+                      if (mounted) {
                         setState(() {
                           _addNewCardFormVisible = false;
                         });
-                      },
-                      onAddNewCard: (CardModel card) async {
-                        await cardsNotifier.addCard(card);
-                        if (mounted) {
-                          setState(() {
-                            _addNewCardFormVisible = false;
-                          });
-                        }
-                      },
-                    ),
-                    SortAndFilterModal(
-                      isVisible: _sortAndFilterModalVisible,
-                      onClose: () {
-                        setState(() {
-                          _sortAndFilterModalVisible = false;
-                        });
-                      },
-                      onApplyFilter: _onApplyFilter,
-                    ),
-                    Positioned(
-                      bottom: 4,
-                      right: 4,
-                      child: Text(FlavorService.getFlavor().getLabel(),
-                          textAlign: TextAlign.left,
-                          style: const TextStyle(
-                              fontFamily: Fonts.rubik,
-                              fontSize: 12,
-                              fontWeight: FontWeight.w600,
-                              color: ThemeColors.yellow)),
-                    ),
-                  ])),
-            ),
-          );
-        },
-      );
-    });
+                      }
+                    },
+                  ),
+                  SortAndFilterModal(
+                    isVisible: _sortAndFilterModalVisible,
+                    onClose: () {
+                      setState(() {
+                        _sortAndFilterModalVisible = false;
+                      });
+                    },
+                    onApplyFilter: _onApplyFilter,
+                  ),
+                  Positioned(
+                    bottom: 4,
+                    right: 4,
+                    child: Text(FlavorService.getFlavor().getLabel(),
+                        textAlign: TextAlign.left,
+                        style: const TextStyle(
+                            fontFamily: Fonts.rubik,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w600,
+                            color: ThemeColors.yellow)),
+                  ),
+                ])),
+          ),
+        );
+      },
+    );
   }
 }

--- a/lib/screens/locked_screen.dart
+++ b/lib/screens/locked_screen.dart
@@ -36,13 +36,13 @@ class _LockedScreenState extends State<LockedScreen> {
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           const SizedBox(height: 48),
-          Icon(
+          const Icon(
             Icons.lock_outlined,
             color: ThemeColors.white1,
             size: 48,
           ),
           const SizedBox(height: 16),
-          Text(
+          const Text(
             "App is locked",
             style: TextStyle(
                 fontFamily: Fonts.rubik,
@@ -53,8 +53,8 @@ class _LockedScreenState extends State<LockedScreen> {
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 16),
-          Text(
-            "App is locked, unlock it.",
+          const Text(
+            "Authenticate to access your cards",
             style: TextStyle(
                 fontFamily: Fonts.rubik,
                 color: ThemeColors.white2,

--- a/lib/screens/locked_screen.dart
+++ b/lib/screens/locked_screen.dart
@@ -1,0 +1,83 @@
+import 'package:cards/components/shared/button.dart';
+import 'package:cards/config/colors.dart';
+import 'package:cards/config/fonts.dart';
+import 'package:cards/providers/auth_notifier.dart';
+import 'package:cards/providers/preferences_notifier.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+class LockedScreen extends StatefulWidget {
+  const LockedScreen({super.key});
+
+  @override
+  State<LockedScreen> createState() => _LockedScreenState();
+}
+
+class _LockedScreenState extends State<LockedScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      AuthNotifier authNotifier = context.read<AuthNotifier>();
+      PreferencesNotifier prefsNotifier = context.read<PreferencesNotifier>();
+      if (authNotifier.needsAuth(prefsNotifier.prefs.useDeviceAuth)) {
+        authNotifier.authenticate();
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+        child: SizedBox(
+      width: double.infinity,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          const SizedBox(height: 48),
+          Icon(
+            Icons.lock_outlined,
+            color: ThemeColors.white1,
+            size: 48,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            "App is locked",
+            style: TextStyle(
+                fontFamily: Fonts.rubik,
+                fontWeight: FontWeight.bold,
+                color: ThemeColors.white1,
+                decoration: TextDecoration.none,
+                fontSize: 24),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            "App is locked, unlock it.",
+            style: TextStyle(
+                fontFamily: Fonts.rubik,
+                color: ThemeColors.white2,
+                decoration: TextDecoration.none),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          Consumer<AuthNotifier>(builder: (conext, authNotifier, _) {
+            return Button(
+              icon: Icons.fingerprint_outlined,
+              label: "Unlock",
+              buttonType: ButtonType.primary,
+              padding: EdgeInsets.fromLTRB(16, 8, 16, 8),
+              color: ThemeColors.blue,
+              disabled: authNotifier.isAuthInProgress(),
+              labelColor: ThemeColors.white1,
+              onTap: () {
+                authNotifier.authenticate();
+              },
+            );
+          }),
+        ],
+      ),
+    ));
+  }
+}

--- a/lib/screens/locked_screen.dart
+++ b/lib/screens/locked_screen.dart
@@ -62,12 +62,12 @@ class _LockedScreenState extends State<LockedScreen> {
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 16),
-          Consumer<AuthNotifier>(builder: (conext, authNotifier, _) {
+          Consumer<AuthNotifier>(builder: (context, authNotifier, _) {
             return Button(
               icon: Icons.fingerprint_outlined,
               label: "Unlock",
               buttonType: ButtonType.primary,
-              padding: EdgeInsets.fromLTRB(16, 8, 16, 8),
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
               color: ThemeColors.blue,
               disabled: authNotifier.isAuthInProgress(),
               labelColor: ThemeColors.white1,

--- a/lib/screens/preferences.dart
+++ b/lib/screens/preferences.dart
@@ -5,6 +5,8 @@ import 'package:cards/config/colors.dart';
 import 'package:cards/config/fonts.dart';
 import 'package:cards/providers/preferences_notifier.dart';
 import 'package:cards/screens/backup_restore/backup_main.dart';
+import 'package:cards/services/auth_service.dart';
+import 'package:cards/services/platform_service.dart';
 import 'package:cards/services/toast_service.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart' show Icons;
@@ -63,21 +65,21 @@ class PreferencesScreen extends StatelessWidget {
                           MenuItemWithSwitch(
                               checked: prefsNotifier.prefs.maskCardNumber,
                               icon: Icons.numbers_outlined,
-                              title: "Mask Card Number",
+                              title: "Hide card number",
                               onChange: (bool newValue) {
                                 prefsNotifier.setMaskCardNumber(newValue);
                               }),
                           MenuItemWithSwitch(
                               checked: prefsNotifier.prefs.maskCVV,
                               icon: Icons.credit_card_outlined,
-                              title: "Mask CVV",
+                              title: "Hide CVV",
                               onChange: (bool newValue) {
                                 prefsNotifier.setMaskCVV(newValue);
                               }),
                           MenuItemWithSwitch(
                             checked: prefsNotifier.prefs.enableNotifications,
                             title: "Notifications",
-                            disabled: true,
+                            disabled: false,
                             icon: Icons.notifications_outlined,
                             onChange: (bool newValue) {
                               prefsNotifier.setEnableNotifications(newValue);
@@ -87,7 +89,14 @@ class PreferencesScreen extends StatelessWidget {
                               checked: prefsNotifier.prefs.useDeviceAuth,
                               icon: Icons.lock_outlined,
                               title: "Use screen lock",
-                              disabled: true,
+                              desc: PlatformService.isAndroid() &&
+                                      !AuthService.isAuthSupported()
+                                  // TODO: navigate to settings on press
+                                  // TODO: update AuthNotifier on app-state changes
+                                  ? "Please set up a device PIN or biometrics in your phone settings."
+                                  : null,
+                              descColor: ThemeColors.red,
+                              disabled: !AuthService.isAuthSupported(),
                               onChange: (bool newValue) {
                                 prefsNotifier.setUseDeviceAuth(newValue);
                               }),

--- a/lib/screens/preferences.dart
+++ b/lib/screens/preferences.dart
@@ -27,7 +27,7 @@ class PreferencesScreen extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 Container(
-                    padding: EdgeInsets.fromLTRB(24, 12, 24, 12),
+                    padding: const EdgeInsets.fromLTRB(24, 12, 24, 12),
                     child: Stack(
                       children: [
                         Container(
@@ -43,7 +43,7 @@ class PreferencesScreen extends StatelessWidget {
                         ),
                         Center(
                             child: Padding(
-                          padding: EdgeInsets.only(top: 2),
+                          padding: const EdgeInsets.only(top: 2),
                           child: const Text(
                             "Preferences",
                             textAlign: TextAlign.center,

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,54 @@
+import 'package:cards/services/platform_service.dart';
+import 'package:cards/services/sentry_service.dart';
+import 'package:local_auth/local_auth.dart';
+
+class AuthServiceErrorCodes {
+  static const int calledWithoutInit = 0x101;
+}
+
+class AuthServiceException implements Exception {
+  final String message;
+  final int errorCode;
+  AuthServiceException(this.errorCode, this.message);
+  @override
+  String toString() {
+    return '[AuthServiceException] Error $errorCode: $message';
+  }
+}
+
+class AuthService {
+  static bool _isAuthSupported = false;
+  static bool _initialized = false;
+  static LocalAuthentication? _auth;
+
+  static Future<void> init() async {
+    _auth = LocalAuthentication();
+    _isAuthSupported = !PlatformService.isLinux() &&
+        !PlatformService.isWeb() &&
+        await _auth!.isDeviceSupported();
+    _initialized = true;
+    if (!_isAuthSupported) return;
+  }
+
+  static void _requireInit() {
+    if (!_initialized) {
+      throw AuthServiceException(
+          AuthServiceErrorCodes.calledWithoutInit, "called without init()");
+    }
+  }
+
+  static bool isAuthSupported() {
+    _requireInit();
+    return _isAuthSupported;
+  }
+
+  static Future<bool> authenticate() async {
+    _requireInit();
+    try {
+      return await _auth!.authenticate(localizedReason: "Unlock");
+    } catch (e, stackTrace) {
+      SentryService.error(e, stackTrace);
+    }
+    return false;
+  }
+}

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -48,6 +48,7 @@ class AuthService {
       return await _auth!.authenticate(localizedReason: "Unlock");
     } catch (e, stackTrace) {
       SentryService.error(e, stackTrace);
+      // TODO: show toast here based on what error we get?
     }
     return false;
   }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import file_selector_macos
 import flutter_local_notifications
 import flutter_secure_storage_macos
+import local_auth_darwin
 import local_notifier
 import package_info_plus
 import path_provider_foundation
@@ -21,6 +22,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
+  LocalAuthPlugin.register(with: registry.registrar(forPlugin: "LocalAuthPlugin"))
   LocalNotifierPlugin.register(with: registry.registrar(forPlugin: "LocalNotifierPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 publish_to: none
 version: 0.5.7+40
 environment:
-  sdk: '>=3.2.6 <4.0.0'
+  sdk: ">=3.2.6 <4.0.0"
 dependencies:
   flutter:
     sdk: flutter
@@ -22,6 +22,7 @@ dependencies:
   window_manager: ^0.5.1
   local_notifier: ^0.1.6
   provider: ^6.0.0
+  local_auth: ^3.0.0
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/unit_tests/auth_notifier_test.dart
+++ b/unit_tests/auth_notifier_test.dart
@@ -1,0 +1,133 @@
+import 'package:cards/providers/auth_notifier.dart';
+import 'package:cards/services/auth_service.dart';
+import 'package:flutter/foundation.dart';
+import 'package:test/test.dart';
+
+void main() {
+  setUp(() async {
+    await AuthService.init();
+  });
+
+  test('AuthNotifier initializes with _authenticated = false', () {
+    AuthNotifier notifier = AuthNotifier();
+    expect(notifier.isAuthInProgress(), false);
+  });
+
+  test('isAuthInProgress returns false initially', () {
+    AuthNotifier notifier = AuthNotifier();
+    expect(notifier.isAuthInProgress(), false);
+  });
+
+  test('needsAuth returns false when deviceAuthEnabled is false', () {
+    AuthNotifier notifier = AuthNotifier();
+    bool result = notifier.needsAuth(false);
+    expect(result, false);
+  });
+
+  test('needsAuth returns false when AuthService.isAuthSupported() is false',
+      () {
+    // TODO: complete this test after refactor
+    assert(true);
+  });
+
+  test('needsAuth returns false when already authenticated', () async {
+    // TODO: complete this test after refactor
+    assert(true);
+  });
+
+  test('authenticate returns false if AuthService.isAuthSupported() is false',
+      () async {
+    // TODO: complete this test after refactor
+    assert(true);
+  });
+
+  test('authenticate returns false if already in progress', () async {
+    AuthNotifier notifier = AuthNotifier();
+    // TODO: test passes, but for wrong reasons.
+    // it passes because AuthService.isAuthSupported() returns false
+
+    // Start first authentication (if supported)
+    Future<bool> firstAuth = notifier.authenticate();
+
+    // Try to authenticate again immediately
+    bool secondResult = await notifier.authenticate();
+
+    // Second call should return false (already in progress)
+    expect(secondResult, false);
+
+    // Wait for first to complete
+    await firstAuth;
+  });
+
+  test('authenticate returns cached value if already authenticated', () async {
+    // TODO: test passes, but for wrong reasons.
+    // it passes because AuthService.isAuthSupported() returns false
+
+    AuthNotifier notifier = AuthNotifier();
+    // First call (will attempt authentication)
+    bool firstResult = await notifier.authenticate();
+
+    // Second call should return cached result
+    bool secondResult = await notifier.authenticate();
+
+    // Both results should be the same
+    expect(firstResult, secondResult);
+  });
+
+  test('authenticate notifies listeners on state change', () async {
+    // TODO: complete this test after refactor
+    assert(true);
+  });
+
+  test('isAuthInProgress returns true during authentication', () async {
+    // TODO: complete this test after refactor
+    assert(true);
+  });
+
+  test('authenticate extends ChangeNotifier', () {
+    AuthNotifier notifier = AuthNotifier();
+    expect(notifier, isA<ChangeNotifier>());
+  });
+
+  test('needsAuth checks all three conditions correctly', () async {
+    AuthNotifier notifier = AuthNotifier();
+
+    // Test: deviceAuthEnabled = false
+    expect(notifier.needsAuth(false), false);
+
+    // Test: deviceAuthEnabled = true but AuthService.isAuthSupported() = false
+    if (!AuthService.isAuthSupported()) {
+      expect(notifier.needsAuth(true), false);
+    }
+
+    // Test: both true but already authenticated
+    // Authenticate first
+    await notifier.authenticate();
+    // If we get here and auth was successful, needsAuth should be false
+    bool result = notifier.needsAuth(true);
+    // Either already authenticated or not supported (result = false in both cases)
+    expect(result, isFalse);
+  });
+
+  test('multiple authenticate calls handle concurrent state correctly',
+      () async {
+    // TODO: test passes, but for wrong reasons. complete this test after refactor
+    AuthNotifier notifier = AuthNotifier();
+    List<bool> results = [];
+    // Call authenticate multiple times rapidly
+    results.add(await notifier.authenticate());
+    results.add(await notifier.authenticate());
+    results.add(await notifier.authenticate());
+
+    // After first call completes, subsequent calls should return cached result
+    // or false (if still in progress)
+    expect(results.length, 3);
+  });
+
+  test('AuthNotifier state resets properly for new instance', () async {
+    AuthNotifier notifier1 = AuthNotifier();
+    AuthNotifier notifier2 = AuthNotifier();
+
+    expect(notifier1.isAuthInProgress(), notifier2.isAuthInProgress());
+  });
+}

--- a/unit_tests/auth_service_test.dart
+++ b/unit_tests/auth_service_test.dart
@@ -1,0 +1,52 @@
+import 'package:cards/services/auth_service.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('isAuthSupported throws if called before init', () {
+    expect(() {
+      AuthService.isAuthSupported();
+    },
+        throwsA(predicate((e) =>
+            e is AuthServiceException &&
+            e.errorCode == AuthServiceErrorCodes.calledWithoutInit)));
+  });
+
+  test('authenticate throws if called before init', () async {
+    expect(() async {
+      await AuthService.authenticate();
+    },
+        throwsA(predicate((e) =>
+            e is AuthServiceException &&
+            e.errorCode == AuthServiceErrorCodes.calledWithoutInit)));
+  });
+
+  test('init sets initialized flag', () async {
+    await AuthService.init();
+    // After init, isAuthSupported should not throw
+    expect(() {
+      AuthService.isAuthSupported();
+    }, returnsNormally);
+  });
+
+  test('isAuthSupported returns bool after init', () async {
+    await AuthService.init();
+    bool supported = AuthService.isAuthSupported();
+    expect(supported, isA<bool>());
+  });
+
+  test('authenticate returns bool after init', () async {
+    await AuthService.init();
+    bool result = await AuthService.authenticate();
+    expect(result, isA<bool>());
+  });
+
+  test('AuthServiceException toString includes error code and message',
+      () async {
+    AuthServiceException exception = AuthServiceException(
+        AuthServiceErrorCodes.calledWithoutInit, 'test message');
+    String exceptionString = exception.toString();
+    expect(exceptionString, contains('AuthServiceException'));
+    expect(exceptionString, contains('257')); // 0x101 in decimal
+    expect(exceptionString, contains('test message'));
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <file_selector_windows/file_selector_windows.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
+#include <local_auth_windows/local_auth_plugin.h>
 #include <local_notifier/local_notifier_plugin.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
 #include <sentry_flutter/sentry_flutter_plugin.h>
@@ -21,6 +22,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
+  LocalAuthPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("LocalAuthPlugin"));
   LocalNotifierPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("LocalNotifierPlugin"));
   ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_windows
   flutter_secure_storage_windows
+  local_auth_windows
   local_notifier
   screen_retriever_windows
   sentry_flutter


### PR DESCRIPTION
This PR contains following changes:
1. Introduce `local_auth` package, and integrate it. When screen lock is enabled from preferences, prompt for device auth (either biometric/pin/pattern) on app startup, add a `LockedScreen` screen to show a "auth required" state with a button to prompt the system auth dialog again.
2. Implement `desc` and expose `descColor` for `MenuItem`s.
3. `MainActivity` now is a `FlutterFragmentActivity` instead of `FlutterActivity` because activity needs to be a fragment activity for local auth to be used (I think, don't know for sure)
4. Fix how `disabled` taps are treated for `MenuItem`.
5. Enable notification option in preferences since it's now implemented.